### PR TITLE
ci: add Kimi Code Review Action

### DIFF
--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -1,0 +1,21 @@
+name: Kimi Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: howardpen9/kimi-code-reviewer@v1
+        with:
+          kimi_api_key: ${{ secrets.MOONSHOT_API_KEY }}
+          language: zh-TW
+          fail_on: never

--- a/src/kimi-runner.ts
+++ b/src/kimi-runner.ts
@@ -3,11 +3,17 @@ import * as path from 'path'
 import * as os from 'os'
 import * as fs from 'fs'
 
+/** Configuration for running a Kimi CLI session */
 export interface KimiRunConfig {
+  /** The analysis prompt to send to Kimi */
   prompt: string
+  /** Absolute path to the codebase root directory */
   workDir?: string
+  /** Resume a specific session by ID */
   sessionId?: string
+  /** Enable thinking mode for deeper analysis */
   thinking?: boolean
+  /** Timeout in milliseconds (default: 600000) */
   timeoutMs?: number
 }
 


### PR DESCRIPTION
## Summary
- Add Kimi Code Review GitHub Action workflow
- Add JSDoc comments to `KimiRunConfig` interface

## Purpose
Test that `howardpen9/kimi-code-reviewer@v1` works on external repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)